### PR TITLE
add logging module to mac_v3_signing

### DIFF
--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -31,6 +31,22 @@ class roles_profiles::profiles::mac_v3_signing {
 
             # we can add worker setup here like in gecko_t_osx_1014_generic_worker.pp
 
+            class { 'roles_profiles::profiles::logging':
+                # The logging module tags the logs with:
+                # hostname: hostname
+                # workerId: short hostname
+                # workerGroup: mdcN (3rd dot-separated string in fqdn)
+                # workerType: $worker_type
+                worker_type => $worker_type,
+                # If not using the default gcp project "fx-worker-logging-prod",
+                # vault secrets are required for:
+                # stackdriver.${stackdriver_project}.keyid
+                # stackdriver.${stackdriver_project}.key
+                # stackdriver.${stackdriver_project}.clientid
+                # For a service account with logging write access.
+                stackdriver_project => 'fx-worker-logging-prod',
+            }
+
             include dirs::tools
             class { 'scriptworker_prereqs': }
 


### PR DESCRIPTION
@srfraser 
https://bugzilla.mozilla.org/show_bug.cgi?id=1571952
Applying this will require running puppet twice if coreutils is not installed; because the google vault plugin requires coreutils from homebrew, and that requires a second run to be found correctly from puppet (I am removing homebrew soon and this dependency problem will be resolved).